### PR TITLE
Add program ability to list out schedule

### DIFF
--- a/src/main/java/seedu/duke/Duke.java
+++ b/src/main/java/seedu/duke/Duke.java
@@ -10,7 +10,7 @@ public class Duke {
     static ArrayList<Event> cca = new ArrayList<>(); // for file input
     private static TestManager testManager = new TestManager(test);
     private static CcaManager ccaManager = new CcaManager(cca);
-    private static ListSchedule listSchedule = new ListSchedule(cca, test);
+    private static ListSchedule listSchedule = new ListSchedule(classes, cca, test);
 
     /**
      * Main entry-point for the java.duke.Duke application.

--- a/src/main/java/seedu/duke/Duke.java
+++ b/src/main/java/seedu/duke/Duke.java
@@ -8,6 +8,8 @@ public class Duke {
     static ArrayList<Event> cca = new ArrayList<>(); // for file input
     private static TestManager testManager = new TestManager(test);
     private static CcaManager ccaManager = new CcaManager(cca);
+    private static ListSchedule listSchedule = new ListSchedule(cca, test);
+
     /**
      * Main entry-point for the java.duke.Duke application.
      */
@@ -44,6 +46,8 @@ public class Duke {
                 testManager.deleteTest(checkCommand);
             } else if (checkCommand[0].equals("delete") && checkCommand[1].equals("cca")) {
                 ccaManager.deleteCca(checkCommand);
+            } else if (checkCommand[0].equals("list")) {
+                listSchedule.printAllEvents();
             } else if (checkCommand[0].equals("bye")) {
                 break;
             }

--- a/src/main/java/seedu/duke/ListSchedule.java
+++ b/src/main/java/seedu/duke/ListSchedule.java
@@ -1,0 +1,15 @@
+package seedu.duke;
+
+import java.util.ArrayList;
+
+public class ListSchedule {
+    private final ArrayList<String> events;
+
+    public ListSchedule(ArrayList<String> events) {
+        this.events = events;
+    }
+
+    public void printAllEvents() {
+        events.stream().forEach(System.out::println);
+    }
+}

--- a/src/main/java/seedu/duke/ListSchedule.java
+++ b/src/main/java/seedu/duke/ListSchedule.java
@@ -3,19 +3,23 @@ package seedu.duke;
 import java.util.ArrayList;
 
 public class ListSchedule {
-    private final ArrayList<Event> cca;
-    private final ArrayList<Event> test;
+    private final ArrayList<Event> classes;
+    private final ArrayList<Event> ccas;
+    private final ArrayList<Event> tests;
 
-    public ListSchedule(ArrayList<Event> cca, ArrayList<Event> test) {
-        this.cca = cca;
-        this.test = test;
+    public ListSchedule(ArrayList<Event> classes, ArrayList<Event> ccas, ArrayList<Event> tests) {
+        this.classes = classes;
+        this.ccas = ccas;
+        this.tests = tests;
     }
 
     public void printAllEvents() {
+        System.out.println("Class:");
+        printArrayPaddedNumbers(classes);
         System.out.println("CCA:");
-        printArrayPaddedNumbers(cca);
+        printArrayPaddedNumbers(ccas);
         System.out.println("Test:");
-        printArrayPaddedNumbers(test);
+        printArrayPaddedNumbers(tests);
     }
 
     private void printArrayPaddedNumbers(ArrayList<Event> eventArr) {

--- a/src/main/java/seedu/duke/ListSchedule.java
+++ b/src/main/java/seedu/duke/ListSchedule.java
@@ -3,13 +3,24 @@ package seedu.duke;
 import java.util.ArrayList;
 
 public class ListSchedule {
-    private final ArrayList<String> events;
+    private final ArrayList<Event> cca;
+    private final ArrayList<Event> test;
 
-    public ListSchedule(ArrayList<String> events) {
-        this.events = events;
+    public ListSchedule(ArrayList<Event> cca, ArrayList<Event> test) {
+        this.cca = cca;
+        this.test = test;
     }
 
     public void printAllEvents() {
-        events.stream().forEach(System.out::println);
+        System.out.println("CCA:");
+        printArrayPaddedNumbers(cca);
+        System.out.println("Test:");
+        printArrayPaddedNumbers(test);
+    }
+
+    private void printArrayPaddedNumbers(ArrayList<Event> eventArr) {
+        for (int i = 0; i < eventArr.size(); i++) {
+            System.out.println(i + 1 + ". " + eventArr.get(i));
+        }
     }
 }


### PR DESCRIPTION
fixes #15 

User can enter `list` to print out the schedule for classes, ccas and tests. This are padded with numbers for the user to easily delete them.