### PR TITLE
Fix controlmanager class validators

### DIFF
--- a/src/main/java/seedu/duke/controller/ControlManager.java
+++ b/src/main/java/seedu/duke/controller/ControlManager.java
@@ -124,6 +124,11 @@ public class ControlManager {
                 && modelType == ModelType.EVENT) {
             throw new InvalidModelException();
         }
+
+        if ((commandType == CommandType.FIND || commandType == CommandType.LIST)
+                && (modelType != ModelType.EVENT && modelType != ModelType.CONTACT && modelType != ModelType.QUIZ)) {
+            throw new InvalidModelException();
+        }
     }
 
     /**


### PR DESCRIPTION
Add a validator to check if list or find command are paired with
incompatible model types (class, cca, test and tuition).

Fixes #309 